### PR TITLE
Romano-Bulgarian Union Fix

### DIFF
--- a/ANSWR MP Edit v0.1/decisions/Romania.txt
+++ b/ANSWR MP Edit v0.1/decisions/Romania.txt
@@ -95,7 +95,8 @@ political_decisions = {
         }
         allow = {         
             war = no           
-            ROM = {
+            nationalism_n_imperialism = 1
+	    ROM = {
                 all_core = {
                     OR = {
                         owned_by = THIS
@@ -148,7 +149,7 @@ political_decisions = {
 				all_core = { add_core = BRO secede_province = THIS }
 			}
             add_accepted_culture = romanian
-            #add_accepted_culture = bulgarian #Not real culture! (TODO)
+	    add_accepted_culture = iskhor
             add_accepted_culture = westturkish
         }
 		ai_will_do = { factor = 1 }


### PR DESCRIPTION
Fixed Romano-Bulgarian Union not giving Iskhor, added Nat & Imp requirement to help balance the fact that Romania starts united. Could be changed to State & Gov if preferred.